### PR TITLE
window: Fix sidebar styles

### DIFF
--- a/src/ui/window.ui
+++ b/src/ui/window.ui
@@ -73,11 +73,6 @@
                     <property name="orientation">vertical</property>
                     <property name="width-request">300</property>
 
-                    <style>
-                      <class name="view"/>
-                      <class name="sidebar"/>
-                    </style>
-
                     <child>
                       <object class="AdwHeaderBar" id="sidebar_headerbar">
                         <property name="show-end-title-buttons">false</property>
@@ -151,6 +146,10 @@
                       <object class="EartagSidebar" id="sidebar"/>
                     </child>
                   </object>
+                </child>
+
+                <child type="separator">
+                  <object class="GtkSeparator"/>
                 </child>
 
                 <child type="content">

--- a/src/ui/window.ui
+++ b/src/ui/window.ui
@@ -73,6 +73,10 @@
                     <property name="orientation">vertical</property>
                     <property name="width-request">300</property>
 
+                    <style>
+                      <class name="background"/>
+                    </style>
+
                     <child>
                       <object class="AdwHeaderBar" id="sidebar_headerbar">
                         <property name="show-end-title-buttons">false</property>


### PR DESCRIPTION
We don't use .view for sidebars, and while .sidebar provides a separator, it's not correctly positioned when folded.