### PR TITLE
Help overlay and GNOME HIG

### DIFF
--- a/src/eartag.gresource.xml
+++ b/src/eartag.gresource.xml
@@ -15,7 +15,7 @@
     <file>ui/fileview.ui</file>
     <file>ui/removaldiscardwarning.ui</file>
     <file>ui/sidebar.ui</file>
-    <file>ui/shortcuts.ui</file>
+    <file alias="gtk/help-overlay.ui">ui/shortcuts.ui</file>
     <file>ui/nofile.ui</file>
     <file>ui/window.ui</file>
     <file>style.css</file>

--- a/src/main.py
+++ b/src/main.py
@@ -36,7 +36,7 @@ gi.require_version('Adw', '1')
 from gi.repository import Adw, Gtk, Gio
 
 from .common import is_valid_music_file
-from .window import EartagWindow, EartagShortcutsWindow
+from .window import EartagWindow
 from .file import EartagFileManager
 
 class Application(Adw.Application):
@@ -70,7 +70,6 @@ class Application(Adw.Application):
         if not win:
             win = EartagWindow(application=self, paths=self.paths)
         self.create_action('about', self.on_about_action)
-        self.create_action('shortcuts', self.on_shortcuts_action)
         self.create_action('open_file', self.on_open_file_action)
         self.set_accels_for_action('app.open_file', ('<Ctrl>o', None))
         self.create_action('save', self.on_save_action)
@@ -148,11 +147,6 @@ Opened files:
         about.set_transient_for(self.props.active_window)
 
         about.present()
-
-    def on_shortcuts_action(self, *args):
-        win = self.props.active_window
-        shortcuts = EartagShortcutsWindow(win)
-        shortcuts.present()
 
     def on_open_file_action(self, widget, _):
         window = self.get_active_window()

--- a/src/ui/nofile.ui
+++ b/src/ui/nofile.ui
@@ -55,7 +55,7 @@
 
                 <child>
                   <object class="GtkButton" id="open_file">
-                    <property name="label" translatable="yes">Open a file</property>
+                    <property name="label" translatable="yes">Open File</property>
                     <property name="halign">center</property>
                     <signal name="clicked" handler="on_add_file"/>
 
@@ -69,7 +69,7 @@
 
                 <child>
                   <object class="GtkButton" id="open_folder">
-                    <property name="label" translatable="yes">Open a folder</property>
+                    <property name="label" translatable="yes">Open Folder</property>
                     <property name="halign">center</property>
                     <signal name="clicked" handler="on_add_folder"/>
 

--- a/src/ui/shortcuts.ui
+++ b/src/ui/shortcuts.ui
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <requires lib="gtk" version="4.0"/>
-  <template class="EartagShortcutsWindow" parent="GtkShortcutsWindow">
-    <property name="modal">true</property>
+  <object class="GtkShortcutsWindow" id="help_overlay">
+    <property name="modal">True</property>
     <child>
       <object class="GtkShortcutsSection">
         <property name="section-name">shortcuts</property>
@@ -10,37 +9,44 @@
 
         <child>
           <object class="GtkShortcutsGroup">
-            <property name="title" translatable="yes">Files</property>
+            <property name="title" translatable="yes" context="shortcut window">General</property>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="accelerator">&lt;ctrl&gt;O</property>
-                <property name="title" translatable="yes">Open files</property>
+                <property name="action-name">app.open_file</property>
+                <property name="title" translatable="yes" context="shortcut window">Open files</property>
               </object>
             </child>
 
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="accelerator">&lt;ctrl&gt;S</property>
-                <property name="title" translatable="yes">Save all modified files</property>
+                <property name="action-name">app.save</property>
+                <property name="title" translatable="yes" context="shortcut window">Save all modified files</property>
               </object>
             </child>
 
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="accelerator">&lt;ctrl&gt;J</property>
-                <property name="title" translatable="yes">Select previous file in sidebar</property>
+                <property name="action-name">app.previous_file</property>
+                <property name="title" translatable="yes" context="shortcut window">Select previous file in sidebar</property>
               </object>
             </child>
 
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="accelerator">&lt;ctrl&gt;L</property>
-                <property name="title" translatable="yes">Select next file in sidebar</property>
+                <property name="action-name">app.next_file</property>
+                <property name="title" translatable="yes" context="shortcut window">Select next file in sidebar</property>
+              </object>
+            </child>
+
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="action-name">win.show-help-overlay</property>
+                <property name="title" translatable="yes" context="shortcut window">Keyboard shortcuts</property>
               </object>
             </child>
           </object>
         </child>
       </object>
     </child>
-  </template>
+  </object>
 </interface>

--- a/src/ui/window.ui
+++ b/src/ui/window.ui
@@ -232,15 +232,15 @@
   <menu id="primary_menu">
     <section>
       <item>
-        <attribute name="label" translatable="yes">_Open file</attribute>
+        <attribute name="label" translatable="yes">_Open File</attribute>
         <attribute name="action">app.open_file</attribute>
       </item>
       <item>
-        <attribute name="label" translatable="yes">O_pen folder</attribute>
+        <attribute name="label" translatable="yes">O_pen Folder</attribute>
         <attribute name="action">app.open_folder</attribute>
       </item>
       <item>
-        <attribute name="label" translatable="yes">S_ave cover to file</attribute>
+        <attribute name="label" translatable="yes">_Save Cover to File</attribute>
         <attribute name="action">app.save_cover</attribute>
       </item>
     </section>

--- a/src/ui/window.ui
+++ b/src/ui/window.ui
@@ -246,8 +246,8 @@
     </section>
     <section>
       <item>
-        <attribute name="label" translatable="yes">_Keyboard shortcuts</attribute>
-        <attribute name="action">app.shortcuts</attribute>
+        <attribute name="label" translatable="yes">_Keyboard Shortcuts</attribute>
+        <attribute name="action">win.show-help-overlay</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">_About Ear Tag</attribute>

--- a/src/window.py
+++ b/src/window.py
@@ -91,13 +91,6 @@ class EartagNoFile(Adw.Bin):
         window.open_mode = EartagFileManager.LOAD_OVERWRITE
         window.show_file_chooser(folders=True)
 
-@Gtk.Template(resource_path='/app/drey/EarTag/ui/shortcuts.ui')
-class EartagShortcutsWindow(Gtk.ShortcutsWindow):
-    __gtype_name__ = 'EartagShortcutsWindow'
-
-    def __init__(self, parent):
-        super().__init__(transient_for=parent)
-
 @Gtk.Template(resource_path='/app/drey/EarTag/ui/window.ui')
 class EartagWindow(Adw.ApplicationWindow):
     __gtype_name__ = 'EartagWindow'


### PR DESCRIPTION
**application: Remove excessive show-help-overlay action**

> We don't need an extra action to show help-overlay. It already managed by GTK.

**application: Comply GNOME HIG Writing Styles**

> This patch ensures that Eartag follows GNOME Human Interface Guidelines (HIG) writing style. More information about writing styles can be found here: https://developer.gnome.org/hig/guidelines/writing-style.html